### PR TITLE
Add sentence bounds

### DIFF
--- a/hw3/param_model_factory.py
+++ b/hw3/param_model_factory.py
@@ -2,7 +2,7 @@ import math
 from typing import List, Tuple
 from collections import defaultdict
 
-from pos_sentence import POSSentence
+from pos_sentence import POSSentence, START_TAG, STOP_TAG, UNKNOWN
 
 ADD_K_EMISSION = 'add_k_emission'
 ADD_K_TRANSITION = 'add_k_transition'

--- a/hw3/param_model_factory.py
+++ b/hw3/param_model_factory.py
@@ -75,9 +75,7 @@ class TransitionModel:
 
     @staticmethod
     def _get_ngram(length: int, idx: int, tokens: List[str]) -> Tuple[str]:
-        if idx >= length - 1:
-            return tuple(tokens[i] for i in range(idx - length + 1, idx + 1))
-        return tuple([START_TAG] * (length - idx - 1) + tokens[:idx + 1])
+        return tuple(tokens[i] for i in range(idx - length + 1, idx + 1))
 
     def train(self, train_sentences: List[POSSentence]):
         self._less_one_ngram_count[tuple([START_TAG] * (self.ngram - 1))] = len(train_sentences)

--- a/hw3/param_model_factory.py
+++ b/hw3/param_model_factory.py
@@ -4,11 +4,8 @@ from collections import defaultdict
 
 from pos_sentence import POSSentence
 
-UNKNOWN = '<UNK>'
-START_TAG = "<s>"
 ADD_K_EMISSION = 'add_k_emission'
 ADD_K_TRANSITION = 'add_k_transition'
-
 
 ### start of Emission Model
 class EmissionModel:
@@ -74,7 +71,7 @@ class TransitionModel:
         self.ngram = ngram
         self._ngram_count = defaultdict(int)
         self._less_one_ngram_count = defaultdict(int)
-        self.avail_tags = set()
+        self.avail_tags = set(START_TAG, STOP_TAG)
 
     @staticmethod
     def _get_ngram(length: int, idx: int, tokens: List[str]) -> Tuple[str]:
@@ -84,9 +81,10 @@ class TransitionModel:
 
     def train(self, train_sentences: List[POSSentence]):
         self._less_one_ngram_count[tuple([START_TAG] * (self.ngram - 1))] = len(train_sentences)
+        self._less_one_ngram_count[tuple([STOP_TAG] * (self.ngram - 1))] = len(train_sentences)        
         for sentences in train_sentences:
             tags = sentences.tags
-            for i in range(len(tags)):
+            for i in range(2, len(tags)):
                 self.avail_tags.add(tags[i])
                 self._ngram_count[self._get_ngram(self.ngram, i, tags)] += 1
                 self._less_one_ngram_count[self._get_ngram(self.ngram - 1, i, tags)] += 1

--- a/hw3/pos_sentence.py
+++ b/hw3/pos_sentence.py
@@ -1,7 +1,12 @@
+UNKNOWN = '<UNK>'
+START_WORD = 'START'
+STOP_WORD = 'STOP'
+START_TAG = '^'
+STOP_TAG = '$'
 class POSSentence:
-    def __init__(self, words, tag_sequence=None):
-        self.words = words
-        self.tags = tag_sequence
+    def __init__(self, words, tag_sequence=None, ngram=3):
+        self.words = [START_WORD]*(ngram-1) + words + [STOP_WORD]*(ngram-1)
+        self.tags = [START_TAG]*(ngram-1) + tag_sequence + [STOP_TAG]*(ngram-1)
 
     def __str__(self):
         if not self.tags:

--- a/hw3/pos_tagger.py
+++ b/hw3/pos_tagger.py
@@ -4,8 +4,7 @@
 import re
 
 from param_model_factory import get_emission_model, get_transition_model, ADD_K_EMISSION, ADD_K_TRANSITION
-from pos_sentence import POSSentence
-
+from pos_sentence import POSSentence, START_TAG, STOP_TAG
 
 def load_data(sentence_file, tag_file=None):
     """Loads data from two files: one containing sentences and one containing tags.
@@ -39,9 +38,6 @@ def load_data(sentence_file, tag_file=None):
         word = re.sub(r'^\d+,', '', word_line)[1:-1]
         tag = re.sub(r'^\d+,', '', tag_line)[1:-1] if tag_file else None
         if word == '-DOCSTART-':
-            curr_words.append('-DOCSTART-')
-            if tag_file:
-                curr_tags.append(tag)
             if curr_words:
                 sentence = POSSentence([*curr_words])
                 if tag_file:


### PR DESCRIPTION
Sorry for the confusion on the main branch, i'm using a new git environment and i got lost where i was.

This PR is to change how we're representing the sentences. The reason for this is so that the q and e matrices are easier to generate. This also simplifies the viterbi decoding 

I changed POSSentence to do the following: START START sentence STOP STOP -> ^ ^ tags $ $ 

I then made sure less_one_ngram counts for START START and STOP STOP = len(train_data)

ngram generation is now easy, we loop from ngram-1 -> len(tags), then we never get ngrams with length < ngram

I also removed DOCSTART from the tagset and sentences so that we just have START and STOP. 

